### PR TITLE
Changes for add javascript to the header

### DIFF
--- a/Source/upload/admin/controller/extension/shipping/ecpaylogistic.php
+++ b/Source/upload/admin/controller/extension/shipping/ecpaylogistic.php
@@ -740,11 +740,8 @@ class ControllerExtensionShippingecpayLogistic extends Controller
 
 	// 增加javascript
 	public function add_javascript(&$route, &$data, &$output) {
-  				        
-		$this->document->addScript('view/javascript/ecpay/js/jquery.blockUI.js');
-		$this->document->addScript('view/javascript/ecpay/js/ecpaylogistic.js');
-
-		$data['scripts'] = $this->document->getScripts();
+  		$data['scripts'][] = 'view/javascript/ecpay/js/jquery.blockUI.js';
+   		$data['scripts'][] = 'view/javascript/ecpay/js/ecpaylogistic.js';
 	}
 
 	// 電子地圖選擇門市


### PR DESCRIPTION
The code in the add_javascript() function would prevent other extensions to add their javascript files in the header.  The proposed change solve this issue.

Hope this makes sense